### PR TITLE
Codesmell fix - make method static

### DIFF
--- a/PokemonCalcMauiBlazor/Pages/Attackdex.razor.cs
+++ b/PokemonCalcMauiBlazor/Pages/Attackdex.razor.cs
@@ -45,7 +45,7 @@ namespace PkmnCalcMauiBlazor.Pages
         }
         public double SaveProgress { get; set; } = 0.0;
         public static string AttackName { get; set; } = "";
-        private async Task<IEnumerable<string>> SearchForAttackName(string attackName)
+        private static async Task<IEnumerable<string>> SearchForAttackName(string attackName)
         {
             // if text is null or empty, don't return values (drop-down will not open)
             if (string.IsNullOrEmpty(attackName))


### PR DESCRIPTION
Fix Maintainability code smell.
Members that do not access instance data or call instance methods can be marked as static. After you mark the methods as static, the compiler will emit nonvirtual call sites to these members. This can give you a measurable performance gain for performance-sensitive code.