### PR TITLE
Change empty return type to array literal in Search method

### DIFF
--- a/PokemonCalcMauiBlazor/Pages/BasePage.cs
+++ b/PokemonCalcMauiBlazor/Pages/BasePage.cs
@@ -12,7 +12,7 @@ namespace PkmnCalcMauiBlazor.Pages
         {
             // if text is null or empty, don't return values (drop-down will not open)
             if (string.IsNullOrEmpty(name))
-                return Array.Empty<string>();
+                return [];
             var names = await fileSystem.File.ReadAllLinesAsync(pathToData);
             return names.Where(x => x.Contains(name, StringComparison.InvariantCultureIgnoreCase));
         }


### PR DESCRIPTION
Change empty return type to array literal in Search method

Updated the return type for null or empty `name` in the
`SearchForMatchingNamesInFile` method from `Array.Empty<string>()`
to an empty array literal `[]` for conciseness.